### PR TITLE
Changed the export functions so can be used on Linux.

### DIFF
--- a/+Export/export_eigen.m
+++ b/+Export/export_eigen.m
@@ -1,17 +1,20 @@
 function [ ] = export_eigen( exprs, name, export_path, vars )
-res_path = [fileparts(which('Export.export_eigen')), '\res\'];
-current_dir = pwd;
-cd(export_path);
-if ~exist('mex/','dir')
-    mkdir('mex');
+res_path = fullfile(fileparts(which('Export.export_slrt')), 'res');
+
+src_export_path = fullfile(export_path,'src');
+mex_export_path = fullfile(export_path,'mex');
+inc_export_path = fullfile(export_path,'include');
+
+if ~exist(src_export_path,'dir')
+    mkdir(src_export_path);
 end
-if ~exist('src/','dir')
-    mkdir('src');
+if ~exist(mex_export_path,'dir')
+    mkdir(mex_export_path);
 end
-if ~exist('include/','dir')
-    mkdir('include');
+if ~exist(inc_export_path,'dir')
+    mkdir(inc_export_path);
 end
-cd(current_dir);
+
 
 if ~iscell(exprs)
     exprs = {exprs};
@@ -22,21 +25,30 @@ if ~iscell(vars)
 end
 
 % Generate mex file
-export(exprs{:}, 'File', [export_path,name,'_mex'], 'Vars', vars, 'ForceExport', true);
-cd(export_path);
-movefile *.mex* mex
-delete *.cc
-delete *.hh
-cd(current_dir);
+export(exprs{:}, 'File', fullfile(mex_export_path,[name,'_mex']), ...
+    'Vars', vars, 'ForceExport', true);
+
+% movefile([name,'_mex','.',mexext],'mex'); % movefile *mex* mex
+delete(fullfile(mex_export_path,[name,'_mex','.cc'])); % delete *.cc
+delete(fullfile(mex_export_path,[name,'_mex','.hh'])); % delete *.hh
+% cd(current_dir);
 
 % Generate c code
-export(exprs{:}, 'File', [export_path,name], 'Vars', vars, 'TemplateHeader', [res_path, 'template_eigen.h'], 'TemplateFile', [res_path, 'template_eigen.c'], 'BuildMex', false, 'ForceExport', true);
-cd(export_path);
-!rename *.cc *.cpp
-!rename *.hh *.h
-movefile *.cpp* src
-movefile *.h* include
-cd(current_dir);
+export(exprs{:}, 'File', fullfile(export_path,name), ...
+    'Vars', vars, ...
+    'TemplateHeader', fullfile(res_path, 'template_eigen.h'), ...
+    'TemplateFile', fullfile(res_path, 'template_eigen.c'), ...
+    'BuildMex', false, 'ForceExport', true);
+
+movefile(fullfile(export_path,[name,'.cc']),...
+    fullfile(src_export_path,[name,'.cpp']));
+movefile(fullfile(export_path,[name,'.hh']),...
+    fullfile(inc_export_path,[name,'.h']));
+% !rename *.cc *.cpp
+% !rename *.hh *.h
+% movefile *.cpp* src
+% movefile *.h* include
+% cd(current_dir);
 
 end
 

--- a/+Export/export_slrt.m
+++ b/+Export/export_slrt.m
@@ -1,17 +1,20 @@
 function [ ] = export_slrt( exprs, name, export_path, vars )
-res_path = [fileparts(which('Export.export_slrt')), '\res\'];
-current_dir = pwd;
-cd(export_path);
-if ~exist('src/','dir')
-    mkdir('src');
+res_path = fullfile(fileparts(which('Export.export_slrt')), 'res');
+
+src_export_path = fullfile(export_path,'src');
+mex_export_path = fullfile(export_path,'mex');
+mfile_export_path = fullfile(export_path,'m');
+
+if ~exist(src_export_path,'dir')
+    mkdir(src_export_path);
 end
-if ~exist('mex/','dir')
-    mkdir('mex');
+if ~exist(mex_export_path,'dir')
+    mkdir(mex_export_path);
 end
-if ~exist('m/','dir')
-    mkdir('m');
+if ~exist(mfile_export_path,'dir')
+    mkdir(mfile_export_path);
 end
-cd(current_dir);
+
 
 if ~iscell(exprs)
     exprs = {exprs};
@@ -22,30 +25,46 @@ if ~iscell(vars)
 end
 
 % Generate mex file
-export(exprs{:}, 'File', [export_path,name,'_mex'], 'Vars', vars, 'ForceExport', true);
-cd(export_path);
-movefile *mex* mex
-delete *.cc
-delete *.hh
-cd(current_dir);
+export(exprs{:}, 'File', fullfile(mex_export_path,[name,'_mex']), ...
+    'Vars', vars, 'ForceExport', true);
+
+% movefile([name,'_mex','.',mexext],'mex'); % movefile *mex* mex
+delete(fullfile(mex_export_path,[name,'_mex','.cc'])); % delete *.cc
+delete(fullfile(mex_export_path,[name,'_mex','.hh'])); % delete *.hh
+% cd(current_dir);
 
 % Generate c code
-export(exprs{:}, 'File', [export_path,name,'_src'], 'Vars', vars, 'TemplateHeader', [res_path, 'template_slrt.h'], 'TemplateFile', [res_path, 'template_slrt.c'], 'BuildMex', false, 'ForceExport', true);
-cd(export_path);
-!ren *.cc *.c
-!ren *.hh *.h
-movefile *.c* src
-movefile *.h* src
-cd(current_dir);
+export(exprs{:}, 'File', fullfile(src_export_path,[name,'_src']), ...
+    'Vars', vars, ...
+    'TemplateHeader', fullfile(res_path, 'template_slrt.h'), ...
+    'TemplateFile', fullfile(res_path, 'template_slrt.c'), ...
+    'BuildMex', false, 'ForceExport', true);
+
+movefile(fullfile(src_export_path,[name,'_src','.cc']),...
+    fullfile(src_export_path,[name,'_src','.c']));
+movefile(fullfile(src_export_path,[name,'_src','.hh']),...
+    fullfile(src_export_path,[name,'_src','.h']));
+% !ren *.cc *.c
+% !ren *.hh *.h
+% movefile *.c* src
+% movefile *.h* src
+
 
 % Generate Matlab wrapper function
-export(exprs{:}, 'File', [export_path,name], 'Vars', vars, 'TemplateHeader', [res_path, 'template_slrt.h'], 'TemplateFile', [res_path, 'template_slrt.m'], 'BuildMex', false, 'ForceExport', true);
-cd(export_path);
-!ren *.cc *.m
-!ren *.hh *.garbage
-movefile *.m* m
-delete *.garbage
-cd(current_dir);
+export(exprs{:}, 'File', fullfile(mfile_export_path,name),...
+    'Vars', vars, ...
+    'TemplateHeader', fullfile(res_path, 'template_slrt.h'), ...
+    'TemplateFile', fullfile(res_path, 'template_slrt.m'), ...
+    'BuildMex', false, 'ForceExport', true);
 
+movefile(fullfile(mfile_export_path,[name,'.cc']),...
+    fullfile(mfile_export_path,[name,'.m']));
+delete(fullfile(mfile_export_path,[name,'.hh']));
+% !ren *.cc *.m
+% !ren *.hh *.garbage
+% movefile *.m* m
+% delete *.garbage
+
+% 
 end
 

--- a/+Export/res/template_eigen.c
+++ b/+Export/res/template_eigen.c
@@ -11,7 +11,7 @@
 #ifdef _MSC_VER
   #define INLINE __forceinline /* use __forceinline (VC++ specific) */
 #else
-  #define INLINE inline        /* use standard inline */
+  #define INLINE static inline        /* use standard inline */
 #endif
 
 /**
@@ -35,7 +35,7 @@ INLINE double Sec(double x) { return 1.0/cos(x); }
 
 INLINE double ArcSin(double x) { return asin(x); }
 INLINE double ArcCos(double x) { return acos(x); }
-//INLINE double ArcTan(double x) { return atan(x); }
+
 
 /* update ArcTan function to use atan2 instead. */
 INLINE double ArcTan(double x, double y) { return atan2(y,x); }
@@ -64,7 +64,7 @@ StringJoin@@{"\n  ", StringReplace[Riffle[TemplateSlot["final"][[i]], ";\n  "], 
        
 void <*TemplateSlot["name"]*>(<*StringImplode[Table["Eigen::Matrix<double,"<>ToString[TemplateSlot["argoutDims"][[i,1]]]<>","<>ToString[TemplateSlot["argoutDims"][[i,2]]]<>"> &p_" <> TemplateSlot["argouts"][[i]], {i, Length[TemplateSlot["argouts"]]}], ", "]*>, <*StringImplode[Table["const Eigen::Matrix<double,"<>ToString[TemplateSlot["arginDims"][[i,1]]]<>","<>ToString[TemplateSlot["arginDims"][[i,2]]]<>"> &" <> ToString[TemplateSlot["argins"][[i]]], {i, Length[TemplateSlot["argins"]]}], ", "]*>)
 {
-  // Call Subroutines
+  /* Call Subroutines */
 <*StringJoin@@Table[
 "  "<>TemplateSlot["argouts"][[i]]<>"(p_"<>TemplateSlot["argouts"][[i]]<>", "<> StringImplode[Table[ToString[arg], {arg, TemplateSlot["argins"]}], ", "]<>");\n"
   , {i, Length[TemplateSlot["argouts"]]}

--- a/+Export/res/template_eigen.h
+++ b/+Export/res/template_eigen.h
@@ -3,9 +3,10 @@
  * <* DateString[] <> " " <> DateString["TimeZoneName"]  *>
  */
 
-#ifndef <*ToUpperCase[TemplateSlot["name"]]*>_HH
-#define <*ToUpperCase[TemplateSlot["name"]]*>_HH
+#ifndef <*ToUpperCase[TemplateSlot["name"]]*>_H
+#define <*ToUpperCase[TemplateSlot["name"]]*>_H
 #include <Eigen/Dense>
 
 void <*TemplateSlot["name"]*>(<*StringImplode[Table["Eigen::Matrix<double,"<>ToString[TemplateSlot["argoutDims"][[i,1]]]<>","<>ToString[TemplateSlot["argoutDims"][[i,2]]]<>"> &p_" <> TemplateSlot["argouts"][[i]], {i, Length[TemplateSlot["argouts"]]}], ", "]*>, <*StringImplode[Table["const Eigen::Matrix<double,"<>ToString[TemplateSlot["arginDims"][[i,1]]]<>","<>ToString[TemplateSlot["arginDims"][[i,2]]]<>"> &" <> ToString[TemplateSlot["argins"][[i]]], {i, Length[TemplateSlot["argins"]]}], ", "]*>);
-#endif // <*ToUpperCase[TemplateSlot["name"]]*>_HH
+#endif 
+/* <*ToUpperCase[TemplateSlot["name"]]*>_H */

--- a/+Export/res/template_slrt.c
+++ b/+Export/res/template_slrt.c
@@ -11,7 +11,7 @@
 #ifdef _MSC_VER
   #define INLINE __forceinline /* use __forceinline (VC++ specific) */
 #else
-  #define INLINE static inline        /* use standard inline */
+  #define INLINE static __inline__        /* use standard inline */
 #endif
 
 /**
@@ -35,7 +35,6 @@ INLINE double Sec(double x) { return 1.0/cos(x); }
 
 INLINE double ArcSin(double x) { return asin(x); }
 INLINE double ArcCos(double x) { return acos(x); }
-//INLINE double ArcTan(double x) { return atan(x); }
 
 /* update ArcTan function to use atan2 instead. */
 INLINE double ArcTan(double x, double y) { return atan2(y,x); }
@@ -64,7 +63,7 @@ StringJoin@@{"  ", Riffle[TemplateSlot["final"][[i]], ";\n  "], ";\n"}<>
 
 void <*TemplateSlot["name"]*>(<*StringImplode[Table["double *p_" <> TemplateSlot["argouts"][[i]], {i, Length[TemplateSlot["argouts"]]}], ", "]*>, <*StringImplode[Table["const double *"<>ToString[arg], {arg, TemplateSlot["argins"]}], ","]*>)
 {
-  // Call Subroutines
+  /* Call Subroutines */
 <*StringJoin@@Table[
 "  "<>TemplateSlot["argouts"][[i]]<>"(p_"<>TemplateSlot["argouts"][[i]]<>", "<> StringImplode[Table[ToString[arg], {arg, TemplateSlot["argins"]}], ", "]<>");\n"
   , {i, Length[TemplateSlot["argouts"]]}

--- a/+Export/res/template_slrt.h
+++ b/+Export/res/template_slrt.h
@@ -3,8 +3,8 @@
  * <* DateString[] <> " " <> DateString["TimeZoneName"]  *>
  */
 
-#ifndef <*ToUpperCase[TemplateSlot["name"]]*>_HH
-#define <*ToUpperCase[TemplateSlot["name"]]*>_HH
+#ifndef <*ToUpperCase[TemplateSlot["name"]]*>_H
+#define <*ToUpperCase[TemplateSlot["name"]]*>_H
 
 #ifdef MATLAB_MEX_FILE
 #include <tmwtypes.h>
@@ -14,4 +14,5 @@
 
 void <*TemplateSlot["name"]*>(<*StringImplode[Table["double *p_" <> TemplateSlot["argouts"][[i]], {i, Length[TemplateSlot["argouts"]]}], ", "]*>, <*StringImplode[Table["const double *"<>ToString[arg], {arg, TemplateSlot["argins"]}], ","]*>);
 
-#endif // <*ToUpperCase[TemplateSlot["name"]]*>_HH
+#endif 
+/* <*ToUpperCase[TemplateSlot["name"]]*>_H */


### PR DESCRIPTION
* Change export_slrt and export_eigen functions assuming that they export one function at a time. Main changes:
  - Used the specific file name directly to move/delete/rename files
  - Used `fullfile` function instead of string concatenation of path+file.
  - Removed all `cd` commands

* Changed template files
  - removed C++ (//) style comments
  - changed `inline` to `__inline__`